### PR TITLE
Fix Snyk dependency vulnerabilities

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,10 +34,10 @@ repositories {
 
 dependencies {
     // Main dependencies
-    implementation 'com.fasterxml.jackson.core:jackson-databind:2.18.2'
-    implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.18.2'
-    implementation 'org.slf4j:slf4j-api:2.0.16'
-    implementation 'ch.qos.logback:logback-classic:1.5.15'
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.18.9'
+    implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.18.9'
+    implementation 'org.slf4j:slf4j-api:2.0.17'
+    implementation 'ch.qos.logback:logback-classic:1.5.36'
     
     // Modern UI - FlatLaf
     implementation 'com.formdev:flatlaf:3.5.4'

--- a/scripts/antiidle
+++ b/scripts/antiidle
@@ -115,7 +115,7 @@ case "$( uname )" in                #(
   NONSTOP* )        nonstop=true ;;
 esac
 
-CLASSPATH=$APP_HOME/lib/jackson-annotations-2.18.2.jar:$APP_HOME/lib/jackson-core-2.18.2.jar:$APP_HOME/lib/jackson-dataformat-yaml-2.18.2.jar:$APP_HOME/lib/jackson-databind-2.18.2.jar:$APP_HOME/lib/logback-classic-1.5.15.jar:$APP_HOME/lib/slf4j-api-2.0.16.jar:$APP_HOME/lib/flatlaf-intellij-themes-3.5.4.jar:$APP_HOME/lib/flatlaf-3.5.4.jar:$APP_HOME/lib/snakeyaml-2.3.jar:$APP_HOME/lib/logback-core-1.5.15.jar:$APP_HOME/lib/antiidle-2.0.0.jar
+CLASSPATH=$APP_HOME/lib/jackson-annotations-2.18.9.jar:$APP_HOME/lib/jackson-core-2.18.9.jar:$APP_HOME/lib/jackson-dataformat-yaml-2.18.9.jar:$APP_HOME/lib/jackson-databind-2.18.9.jar:$APP_HOME/lib/logback-classic-1.5.36.jar:$APP_HOME/lib/slf4j-api-2.0.17.jar:$APP_HOME/lib/flatlaf-intellij-themes-3.5.4.jar:$APP_HOME/lib/flatlaf-3.5.4.jar:$APP_HOME/lib/snakeyaml-2.3.jar:$APP_HOME/lib/logback-core-1.5.36.jar:$APP_HOME/lib/antiidle-2.0.0.jar
 
 
 # Determine the Java command to use to start the JVM.

--- a/scripts/antiidle.bat
+++ b/scripts/antiidle.bat
@@ -70,7 +70,7 @@ goto fail
 :execute
 @rem Setup the command line
 
-set CLASSPATH=%APP_HOME%\lib\jackson-annotations-2.18.2.jar;%APP_HOME%\lib\jackson-core-2.18.2.jar;%APP_HOME%\lib\jackson-dataformat-yaml-2.18.2.jar;%APP_HOME%\lib\jackson-databind-2.18.2.jar;%APP_HOME%\lib\logback-classic-1.5.15.jar;%APP_HOME%\lib\slf4j-api-2.0.16.jar;%APP_HOME%\lib\flatlaf-intellij-themes-3.5.4.jar;%APP_HOME%\lib\flatlaf-3.5.4.jar;%APP_HOME%\lib\snakeyaml-2.3.jar;%APP_HOME%\lib\logback-core-1.5.15.jar;%APP_HOME%\lib\antiidle-2.0.0.jar
+set CLASSPATH=%APP_HOME%\lib\jackson-annotations-2.18.9.jar;%APP_HOME%\lib\jackson-core-2.18.9.jar;%APP_HOME%\lib\jackson-dataformat-yaml-2.18.9.jar;%APP_HOME%\lib\jackson-databind-2.18.9.jar;%APP_HOME%\lib\logback-classic-1.5.36.jar;%APP_HOME%\lib\slf4j-api-2.0.17.jar;%APP_HOME%\lib\flatlaf-intellij-themes-3.5.4.jar;%APP_HOME%\lib\flatlaf-3.5.4.jar;%APP_HOME%\lib\snakeyaml-2.3.jar;%APP_HOME%\lib\logback-core-1.5.36.jar;%APP_HOME%\lib\antiidle-2.0.0.jar
 
 
 @rem Execute antiidle

--- a/src/test/java/com/upp/security/DependencyVersionTest.java
+++ b/src/test/java/com/upp/security/DependencyVersionTest.java
@@ -1,0 +1,23 @@
+package com.upp.security;
+
+import ch.qos.logback.classic.Logger;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Guards the minimum dependency versions required to address known vulnerabilities.
+ */
+class DependencyVersionTest {
+
+    @Test
+    void usesPatchedJacksonDatabindVersion() {
+        assertEquals("2.18.9", ObjectMapper.class.getPackage().getImplementationVersion());
+    }
+
+    @Test
+    void usesPatchedLogbackVersion() {
+        assertEquals("1.5.36", Logger.class.getPackage().getImplementationVersion());
+    }
+}


### PR DESCRIPTION
## What changed

- upgrade Jackson Databind and YAML from 2.18.2 to 2.18.9
- upgrade Logback Classic/Core from 1.5.15 to 1.5.36
- align the direct SLF4J API declaration with the resolved 2.0.17 version
- regenerate Unix and Windows launch scripts with the patched runtime classpath
- add regression tests that guard the patched Jackson and Logback versions

## Why

The Snyk project reported 15 open and fixable dependency vulnerabilities: 2 critical, 5 high, 7 medium, and 1 low. The issues were rooted in the Jackson 2.18.2 and Logback 1.5.15 dependency families.

## Impact

Packaged applications and generated launchers now resolve the patched Jackson and Logback artifacts. No application behavior or public API is changed.

## Validation

- confirmed the regression tests failed on Jackson 2.18.2 and Logback 1.5.15 before the fix
- `./gradlew test --tests com.upp.security.DependencyVersionTest`
- `./gradlew clean build` (tests, Checkstyle, and SpotBugs)
- Gradle dependency insight confirms Jackson Databind/Core/YAML 2.18.9 and Logback Classic/Core 1.5.36 on `runtimeClasspath`
- `git -c core.whitespace=cr-at-eol diff --check`
